### PR TITLE
Support newer GHCs, newer tdigest

### DIFF
--- a/src/Wrecker/Options.hs
+++ b/src/Wrecker/Options.hs
@@ -4,6 +4,7 @@ module Wrecker.Options where
 
 import Control.Exception
 import Data.Monoid
+import Data.Semigroup (Semigroup(..))
 import Options.Applicative
 import Wrecker.Logger
 
@@ -104,6 +105,25 @@ data PartialOptions = PartialOptions
     , mListTestGroups :: Maybe Bool
     } deriving (Show, Eq)
 
+instance Semigroup PartialOptions where
+    x <> y =
+        PartialOptions
+        { mConcurrency = mConcurrency x <|> mConcurrency y
+        , mBinCount = mBinCount x <|> mBinCount y
+        , mRunStyle = mRunStyle x <|> mRunStyle y
+        , mTimeoutTime = mTimeoutTime x <|> mTimeoutTime y
+        , mDisplayMode = mDisplayMode x <|> mDisplayMode y
+        , mLogLevel = mLogLevel x <|> mLogLevel y
+        , mLogFmt = mLogFmt x <|> mLogFmt y
+        , mMatch = mMatch x <|> mMatch y
+        , mRequestNameColumnSize = mRequestNameColumnSize x <|> mRequestNameColumnSize y
+        , mOutputFilePath = mOutputFilePath x <|> mOutputFilePath y
+        , mSilent = mSilent x <|> mSilent y
+        , murlDisplay = murlDisplay x <|> murlDisplay y
+        , mRecordQuery = mRecordQuery x <|> mRecordQuery y
+        , mListTestGroups = mListTestGroups x <|> mListTestGroups y
+        }
+
 instance Monoid PartialOptions where
     mempty =
         PartialOptions
@@ -122,23 +142,7 @@ instance Monoid PartialOptions where
         , mRecordQuery = Just $ recordQuery defaultOptions
         , mListTestGroups = Just $ listTestGroups defaultOptions
         }
-    mappend x y =
-        PartialOptions
-        { mConcurrency = mConcurrency x <|> mConcurrency y
-        , mBinCount = mBinCount x <|> mBinCount y
-        , mRunStyle = mRunStyle x <|> mRunStyle y
-        , mTimeoutTime = mTimeoutTime x <|> mTimeoutTime y
-        , mDisplayMode = mDisplayMode x <|> mDisplayMode y
-        , mLogLevel = mLogLevel x <|> mLogLevel y
-        , mLogFmt = mLogFmt x <|> mLogFmt y
-        , mMatch = mMatch x <|> mMatch y
-        , mRequestNameColumnSize = mRequestNameColumnSize x <|> mRequestNameColumnSize y
-        , mOutputFilePath = mOutputFilePath x <|> mOutputFilePath y
-        , mSilent = mSilent x <|> mSilent y
-        , murlDisplay = murlDisplay x <|> murlDisplay y
-        , mRecordQuery = mRecordQuery x <|> mRecordQuery y
-        , mListTestGroups = mListTestGroups x <|> mListTestGroups y
-        }
+    mappend = (<>)
 
 completeOptions :: PartialOptions -> Maybe Options
 completeOptions options =

--- a/src/Wrecker/Statistics.hs
+++ b/src/Wrecker/Statistics.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RecordWildCards, BangPatterns, LambdaCase,
-  OverloadedStrings, DataKinds, NamedFieldPuns #-}
+  OverloadedStrings, DataKinds, NamedFieldPuns, CPP #-}
 
 module Wrecker.Statistics
     ( Statistics(..)
@@ -18,6 +18,9 @@ import Data.HashMap.Strict (HashMap)
 import Data.List (sortBy)
 import Data.Maybe (fromMaybe)
 import qualified Data.TDigest as TD
+#if MIN_VERSION_tdigest(0,2,1)
+import qualified Data.TDigest.Postprocess as TD (totalWeight)
+#endif
 import qualified Data.Text as T
 import qualified Network.URI as URI
 import Text.Printf


### PR DESCRIPTION
This is needed for newer versions of GHC. It also would make sense to merge and publish [this PR](https://github.com/skedgeme/next-ref/pull/2) on next-ref for compatibility with newer `stm`.